### PR TITLE
fix: skip recipient id in toBytes for tx type 1 and 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 0.2.1
+
+### Fixed
+- Skip recipient id in `ToBytes` for type 1 and 4 transactions.
+
 ## 0.2.0 - 2018-07-18
 
 Several files and folders have been moved around for guideline compliance - see the [diff](https://github.com/ArkEcosystem/go-crypto/compare/0.1.0...0.2.0) for more details

--- a/crypto/deserializer.go
+++ b/crypto/deserializer.go
@@ -107,22 +107,15 @@ func deserializeVersionOne(bytes []byte, transaction *Transaction) *Transaction 
 		transaction.VendorField = string(HexDecode(Hex2Byte(transaction.VendorFieldHex)))
 	}
 
+	if transaction.Type == TRANSACTION_TYPES.SecondSignatureRegistration || transaction.Type == TRANSACTION_TYPES.MultiSignatureRegistration {
+		publicKey, _ := PublicKeyFromHex(transaction.SenderPublicKey)
+		publicKey.Network.Version = transaction.Network
+
+		transaction.RecipientId = publicKey.ToAddress()
+	}
+
 	if transaction.Id == "" {
 		transaction.Id = transaction.GetId()
-	}
-
-	if transaction.Type == TRANSACTION_TYPES.SecondSignatureRegistration {
-		publicKey, _ := PublicKeyFromHex(transaction.SenderPublicKey)
-		publicKey.Network.Version = transaction.Network
-
-		transaction.RecipientId = publicKey.ToAddress()
-	}
-
-	if transaction.Type == TRANSACTION_TYPES.MultiSignatureRegistration {
-		publicKey, _ := PublicKeyFromHex(transaction.SenderPublicKey)
-		publicKey.Network.Version = transaction.Network
-
-		transaction.RecipientId = publicKey.ToAddress()
 	}
 
 	return transaction

--- a/crypto/deserializer_test.go
+++ b/crypto/deserializer_test.go
@@ -32,6 +32,9 @@ func TestDeserializeTransferWithPassphrase(t *testing.T) {
 	assert.Equal(fixture.Data.Type, transaction.Type)
 	assert.Equal(uint8(30), transaction.Network)
 	assert.Equal(uint8(1), transaction.Version)
+
+	success, _ := transaction.Verify()
+	assert.Equal(success, true)
 }
 
 func TestDeserializeTransferWithSecondPassphrase(t *testing.T) {
@@ -52,6 +55,9 @@ func TestDeserializeTransferWithSecondPassphrase(t *testing.T) {
 	assert.Equal(fixture.Data.Type, transaction.Type)
 	assert.Equal(uint8(30), transaction.Network)
 	assert.Equal(uint8(1), transaction.Version)
+
+	success, _ := transaction.Verify()
+	assert.Equal(success, true)
 }
 
 func TestDeserializeSecondSignatureRegistrationWithPassphrase(t *testing.T) {
@@ -72,6 +78,9 @@ func TestDeserializeSecondSignatureRegistrationWithPassphrase(t *testing.T) {
 	assert.Equal(fixture.Data.Type, transaction.Type)
 	assert.Equal(uint8(30), transaction.Network)
 	assert.Equal(uint8(1), transaction.Version)
+
+	success, _ := transaction.Verify()
+	assert.Equal(success, true)
 
 	// special case as the type 1 transaction itself has no recipientId
 	publicKey, _ := PublicKeyFromHex(transaction.SenderPublicKey)
@@ -96,6 +105,9 @@ func TestDeserializeDelegateRegistrationWithPassphrase(t *testing.T) {
 	assert.Equal(fixture.Data.Type, transaction.Type)
 	assert.Equal(uint8(30), transaction.Network)
 	assert.Equal(uint8(1), transaction.Version)
+
+	success, _ := transaction.Verify()
+	assert.Equal(success, true)
 }
 
 func TestDeserializeDelegateSecondRegistrationWithSecondPassphrase(t *testing.T) {
@@ -116,6 +128,9 @@ func TestDeserializeDelegateSecondRegistrationWithSecondPassphrase(t *testing.T)
 	assert.Equal(fixture.Data.Type, transaction.Type)
 	assert.Equal(uint8(30), transaction.Network)
 	assert.Equal(uint8(1), transaction.Version)
+
+	success, _ := transaction.Verify()
+	assert.Equal(success, true)
 }
 
 func TestDeserializeVoteWithPassphrase(t *testing.T) {
@@ -137,6 +152,9 @@ func TestDeserializeVoteWithPassphrase(t *testing.T) {
 	assert.Equal(fixture.Data.Type, transaction.Type)
 	assert.Equal(uint8(30), transaction.Network)
 	assert.Equal(uint8(1), transaction.Version)
+
+	success, _ := transaction.Verify()
+	assert.Equal(success, true)
 }
 
 func TestDeserializeVoteWithSecondPassphrase(t *testing.T) {
@@ -158,6 +176,9 @@ func TestDeserializeVoteWithSecondPassphrase(t *testing.T) {
 	assert.Equal(fixture.Data.Type, transaction.Type)
 	assert.Equal(uint8(30), transaction.Network)
 	assert.Equal(uint8(1), transaction.Version)
+
+	success, _ := transaction.Verify()
+	assert.Equal(success, true)
 }
 
 func TestDeserializeMultiSignatureRegistrationWithSecondPassphrase(t *testing.T) {
@@ -185,6 +206,9 @@ func TestDeserializeMultiSignatureRegistrationWithSecondPassphrase(t *testing.T)
 	assert.Equal(fixture.Data.Type, transaction.Type)
 	assert.Equal(uint8(23), transaction.Network)
 	assert.Equal(uint8(1), transaction.Version)
+
+	success, _ := transaction.Verify()
+	assert.Equal(success, true)
 }
 
 func TestDeserializeIpfs(t *testing.T) {

--- a/crypto/transaction.go
+++ b/crypto/transaction.go
@@ -147,7 +147,8 @@ func (transaction *Transaction) ToBytes(skipSignature, skipSecondSignature bool)
 	_ = binary.Write(buffer, binary.LittleEndian, uint32(transaction.Timestamp))
 	_ = binary.Write(buffer, binary.LittleEndian, HexDecode(transaction.SenderPublicKey))
 
-	if transaction.RecipientId != "" {
+	skipRecipientId := transaction.Type == TRANSACTION_TYPES.SecondSignatureRegistration || transaction.Type == TRANSACTION_TYPES.MultiSignatureRegistration
+	if transaction.RecipientId != "" && !skipRecipientId {
 		res, err := base58.Decode(transaction.RecipientId)
 
 		if err != nil {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
In second signature and multi signature transactions the recipient id is not supposed to be included in the signature/id calculation. Add an additional check to `toBytes` to explicitely exclude the recipientId. This also allows such transactions to be verified, even if the recipientId is set.

## Types of changes
<!--
What types of changes does your code introduce?
_Put an `x` in the boxes that apply and remove the rest of them: keep this PR as concise, but descriptive, as possible.._
-->

- [X] Bugfix (non-breaking change which fixes an issue)

## Checklist
<!--
_Put an `x` in the boxes that apply and remove this text and the rest of them. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._
-->
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
<!--