### PR TITLE
chore: Fix broken link to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Documentation
 
-You can find installation instructions and detailed instructions on how to use this package at the [dedicated documentation site](https://docs.ark.io/sdk/cryptography/go.html).
+You can find installation instructions and detailed instructions on how to use this package at the [documentation site](https://docs.ark.io/sdk/cryptography/usage.html).
 
 ## Security
 
@@ -23,7 +23,7 @@ If you discover a security vulnerability within this package, please send an e-m
 
 ## Credits
 
-This project exists thanks to all the people who [contribute](../../contributors).
+This project exists thanks to all the people who [contribute](./graphs/contributors).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you discover a security vulnerability within this package, please send an e-m
 
 ## Credits
 
-This project exists thanks to all the people who [contribute](./graphs/contributors).
+This project exists thanks to all the people who [contribute](../../contributors).
 
 ## License
 


### PR DESCRIPTION
Also simplify the link to the contributors, even though both variants
work.