### PR TITLE
Update HTLC claim to support secret of 32 bytes

### DIFF
--- a/crypto/builder_test.go
+++ b/crypto/builder_test.go
@@ -238,7 +238,7 @@ func htlcClaimWithPassphrase(t *testing.T) *Transaction {
 			Asset: &TransactionAsset{
 				Claim: &HtlcClaimAsset{
 					LockTransactionId: "d25c84e544bafc1d1bed9538c67b4275b0b79f49ef6b8677b31a709650442fe9",
-					UnlockSecret: "z]dkm`NFnn9UTvt1`l]CJ[FohcRaqNhZ",
+					UnlockSecret: "7a5d646b6d604e466e6e395554767431606c5d434a5b466f68635261714e685a",
 				},
 			},
 			Nonce: 5,

--- a/crypto/deserializer.go
+++ b/crypto/deserializer.go
@@ -278,7 +278,7 @@ func deserializeHtlcClaim(typeSpecificOffset int, transaction *Transaction) *Tra
 	lockTransactionId := HexEncode(transaction.Serialized[o:o + 32])
 	o += 32
 
-	unlockSecret := string(transaction.Serialized[o:o + 32])
+	unlockSecret := HexEncode(transaction.Serialized[o:o + 32])
 	o += 32
 
 	transaction.Asset = &TransactionAsset{

--- a/crypto/fixtures/transactions/htlc_claim/passphrase-no-vendor-field.json
+++ b/crypto/fixtures/transactions/htlc_claim/passphrase-no-vendor-field.json
@@ -5,7 +5,7 @@
         "asset": {
             "claim": {
                 "lockTransactionId": "d25c84e544bafc1d1bed9538c67b4275b0b79f49ef6b8677b31a709650442fe9",
-                "unlockSecret": "z]dkm`NFnn9UTvt1`l]CJ[FohcRaqNhZ"
+                "unlockSecret": "7a5d646b6d604e466e6e395554767431606c5d434a5b466f68635261714e685a"
             }
         },
         "fee": "0",

--- a/crypto/serializer.go
+++ b/crypto/serializer.go
@@ -177,7 +177,7 @@ func (transaction *Transaction) serializeHtlcLock(ser *bytes.Buffer) {
 
 func (transaction *Transaction) serializeHtlcClaim(ser *bytes.Buffer) {
 	ser.Write(HexDecode(transaction.Asset.Claim.LockTransactionId))
-	ser.Write([]byte(transaction.Asset.Claim.UnlockSecret))
+	ser.Write(HexDecode(transaction.Asset.Claim.UnlockSecret))
 }
 
 func (transaction *Transaction) serializeHtlcRefund(ser *bytes.Buffer) {


### PR DESCRIPTION
This is a followup to https://github.com/ArkEcosystem/core/pull/3392
to support HTLC unlock secret of any 32 bytes, not just 32 characters.
As a result the HTLC unlock secret is now represented with 64 hex chars
instead of verbatim.
